### PR TITLE
Fix parsing of certain spells

### DIFF
--- a/__tests__/constants/EconItems.ts
+++ b/__tests__/constants/EconItems.ts
@@ -7,11 +7,13 @@ export const ScreamFortressCase = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEcaQYBUhXxhztCm83ZGv2eA_MIlMoK9ZFc1yJgmBVEPOK5PDhwdwHMU_AMDMo29RrrDGlmsJQ0A9Ky9LkEfQm7toCQMrkrZokaTZGDU6fTZQH160470vVde5yIvmqxioeb6mr-",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEcaQYBUhXxhztCm83ZGv2eA_MIlMoK9ZFc1yJgmBVEPOK5PDhwdwHMU_AMDMo29RrrDGlmsJQ0A9Ky9LkEfQm7toCQMrkrZokaTZGDU6fTZQH160470vVde5yIvmqxioeb6mr-",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEcaQYBUhXxhztCm83ZGv2eA_MIlMoK9ZFc1yJgmBVEPOK5PDhwdwHMU_AMDMo29RrrDGlmsJQ0A9Ky9LkEfQm7toCQMrkrZokaTZGDU6fTZQH160470vVde5yIvmqxioeb6mr-",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEcaQYBUhXxhztCm83ZGv2eA_MIlMoK9ZFc1yJgmBVEPOK5PDhwdwHMU_AMDMo29RrrDGlmsJQ0A9Ky9LkEfQm7toCQMrkrZokaTZGDU6fTZQH160470vVde5yIvmqxioeb6mr-",
 	descriptions: [
 		{
-			value: "Paint your master piece with one of these community-made War Paints."
+			value: "Paint your master piece with one of these community-made War Paints.",
 		},
 		{ value: " " },
 		{ value: " " },
@@ -39,22 +41,22 @@ export const ScreamFortressCase = {
 		{ value: " " },
 		{ value: "Case Global Bonus Item(s)" },
 		{
-			value: "Paint Cans!\nTaunt Unusualifiers!\nMvM Tickets!\nAnd TF2 Tools!"
+			value: "Paint Cans!\nTaunt Unusualifiers!\nMvM Tickets!\nAnd TF2 Tools!",
 		},
 		{
-			value: "Inspect for full list of unusual effects and more details"
-		}
+			value: "Inspect for full list of unusual effects and more details",
+		},
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=5918&lang=en_US",
-			name: "Item Wiki Page..."
+			name: "Item Wiki Page...",
 		},
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D5219579289808493946",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	name: "Scream Fortress XII War Paint Case",
 	name_color: "7D6D00",
@@ -64,8 +66,8 @@ export const ScreamFortressCase = {
 	market_actions: [
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D5219579289808493946",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	commodity: 1,
 	market_tradable_restriction: 7,
@@ -77,21 +79,21 @@ export const ScreamFortressCase = {
 			internal_name: "Unique",
 			localized_category_name: "Quality",
 			localized_tag_name: "Unique",
-			color: "7D6D00"
+			color: "7D6D00",
 		},
 		{
 			category: "Type",
 			internal_name: "Supply Crate",
 			localized_category_name: "Type",
-			localized_tag_name: "Crate"
+			localized_tag_name: "Crate",
 		},
 		{
 			category: "Collection",
 			internal_name: "Halloween2020Paintkits_collection",
 			localized_category_name: "Collection",
-			localized_tag_name: "Scream Fortress XII Collection"
-		}
-	]
+			localized_tag_name: "Scream Fortress XII Collection",
+		},
+	],
 };
 
 export const AustraliumGoldUnusualAviator = {
@@ -103,8 +105,10 @@ export const AustraliumGoldUnusualAviator = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSMfqIdEs5nqWSMU5OD2IwIlnYPyihXOjLx2Sk5MbUqMcbBnQz4ruyeU2f_ZyXQfXGISGFsGOIKbT2Iqlz5tK_DFybLQekqFw0GLvNW920bOJqONxU904cOrje8xxAqGEZ5cMYXdFa6n3JCf60rz1Nr6jd3",
-	icon_url_large: "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSMfqIdEs5nqWSMU5OD2IwIlnYPyihXOjLx2Sk5MbUqMcbBnQz4ruyeU2f_ZyXQfXGISGFsGOIKbT2Iqlz5tK_DFybLQekqFw0GLvNW920bOJqONxU904cOrje8xxAqGEZ5cMYXdFa6n3JCf60rz1Nr6jd3",
+	icon_url:
+    "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSMfqIdEs5nqWSMU5OD2IwIlnYPyihXOjLx2Sk5MbUqMcbBnQz4ruyeU2f_ZyXQfXGISGFsGOIKbT2Iqlz5tK_DFybLQekqFw0GLvNW920bOJqONxU904cOrje8xxAqGEZ5cMYXdFa6n3JCf60rz1Nr6jd3",
+	icon_url_large:
+    "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSMfqIdEs5nqWSMU5OD2IwIlnYPyihXOjLx2Sk5MbUqMcbBnQz4ruyeU2f_ZyXQfXGISGFsGOIKbT2Iqlz5tK_DFybLQekqFw0GLvNW920bOJqONxU904cOrje8xxAqGEZ5cMYXdFa6n3JCf60rz1Nr6jd3",
 	descriptions: [
 		{ value: "Paint Color: Australium Gold", color: "756b5e" },
 		{ value: "★ Unusual Effect: Kill-a-Watt", color: "ffd700" },
@@ -112,18 +116,18 @@ export const AustraliumGoldUnusualAviator = {
 		{ value: "The Automatic Pilot Pack", color: "e1e10f" },
 		{ value: " " },
 		{ value: "The Aviator Assassin", color: "8b8989" },
-		{ value: "The Sky Captain", color: "8b8989" }
+		{ value: "The Sky Captain", color: "8b8989" },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=30404&lang=en_US",
-			name: "Item Wiki Page..."
+			name: "Item Wiki Page...",
 		},
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D2681663911130303464",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	name: "Unusual Aviator Assassin",
 	name_color: "8650AC",
@@ -133,8 +137,8 @@ export const AustraliumGoldUnusualAviator = {
 	market_actions: [
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D2681663911130303464",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	commodity: 0,
 	market_tradable_restriction: 7,
@@ -146,21 +150,21 @@ export const AustraliumGoldUnusualAviator = {
 			internal_name: "rarity4",
 			localized_category_name: "Quality",
 			localized_tag_name: "Unusual",
-			color: "8650AC"
+			color: "8650AC",
 		},
 		{
 			category: "Type",
 			internal_name: "misc",
 			localized_category_name: "Type",
-			localized_tag_name: "Cosmetic"
+			localized_tag_name: "Cosmetic",
 		},
 		{
 			category: "Class",
 			internal_name: "Spy",
 			localized_category_name: "Class",
-			localized_tag_name: "Spy"
-		}
-	]
+			localized_tag_name: "Spy",
+		},
+	],
 };
 
 export const MannCoSupplyCrateKey = {
@@ -172,19 +176,21 @@ export const MannCoSupplyCrateKey = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEAaR4uURrwvz0N252yVaDVWrRTno9m4ccG2GNqxlQoZrC2aG9hcVGUWflbX_drrVu5UGki5sAij6tOtQ",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEAaR4uURrwvz0N252yVaDVWrRTno9m4ccG2GNqxlQoZrC2aG9hcVGUWflbX_drrVu5UGki5sAij6tOtQ",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEAaR4uURrwvz0N252yVaDVWrRTno9m4ccG2GNqxlQoZrC2aG9hcVGUWflbX_drrVu5UGki5sAij6tOtQ",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEAaR4uURrwvz0N252yVaDVWrRTno9m4ccG2GNqxlQoZrC2aG9hcVGUWflbX_drrVu5UGki5sAij6tOtQ",
 	descriptions: [
 		{ value: "Used to open locked supply crates." },
 		{ value: " " },
-		{ value: "This is a limited use item. Uses: 1", color: "00a000" }
+		{ value: "This is a limited use item. Uses: 1", color: "00a000" },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=5021&lang=en_US",
-			name: "Item Wiki Page..."
-		}
+			name: "Item Wiki Page...",
+		},
 	],
 	name: "Mann Co. Supply Crate Key",
 	name_color: "7D6D00",
@@ -201,15 +207,15 @@ export const MannCoSupplyCrateKey = {
 			internal_name: "Unique",
 			localized_category_name: "Quality",
 			localized_tag_name: "Unique",
-			color: "7D6D00"
+			color: "7D6D00",
 		},
 		{
 			category: "Type",
 			internal_name: "TF_T",
 			localized_category_name: "Type",
-			localized_tag_name: "Tool"
-		}
-	]
+			localized_tag_name: "Tool",
+		},
+	],
 };
 
 export const SpelledAndPaintedFukushima = {
@@ -221,27 +227,29 @@ export const SpelledAndPaintedFukushima = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSLcfMQEs5nqWSMU5OD2NwHzHZdmihXOjLx2Sk5MbUqMcbBnQz4ruyeU3XkYTbKECzcDl1XEeIcYj3H_jeh4bmVED7LSegkQQlRLPEC9m0YaMzdPhQ63dMMrTXuxBAsSBcpKotWfghiZg2B0w",
-	icon_url_large: "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSLcfMQEs5nqWSMU5OD2NwHzHZdmihXOjLx2Sk5MbUqMcbBnQz4ruyeU3XkYTbKECzcDl1XEeIcYj3H_jeh4bmVED7LSegkQQlRLPEC9m0YaMzdPhQ63dMMrTXuxBAsSBcpKotWfghiZg2B0w",
+	icon_url:
+    "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSLcfMQEs5nqWSMU5OD2NwHzHZdmihXOjLx2Sk5MbUqMcbBnQz4ruyeU3XkYTbKECzcDl1XEeIcYj3H_jeh4bmVED7LSegkQQlRLPEC9m0YaMzdPhQ63dMMrTXuxBAsSBcpKotWfghiZg2B0w",
+	icon_url_large:
+    "IzMF03bi9WpSBq-S-ekoE33L-iLqGFHVaU25ZzQNQcXdEH9myp0erksICfSLcfMQEs5nqWSMU5OD2NwHzHZdmihXOjLx2Sk5MbUqMcbBnQz4ruyeU3XkYTbKECzcDl1XEeIcYj3H_jeh4bmVED7LSegkQQlRLPEC9m0YaMzdPhQ63dMMrTXuxBAsSBcpKotWfghiZg2B0w",
 	descriptions: [
 		{ value: "Paint Color: Team Spirit", color: "756b5e" },
 		{ value: "★ Unusual Effect: Aces High", color: "ffd700" },
 		{
 			value: "Halloween: Voices From Below (spell only active during event)",
-			color: "7ea9d1"
+			color: "7ea9d1",
 		},
-		{ value: "You can't tell, but he's furious." }
+		{ value: "You can't tell, but he's furious." },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=395&lang=en_US",
-			name: "Item Wiki Page..."
+			name: "Item Wiki Page...",
 		},
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D11594556976610170043",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	name: "Unusual Furious Fukaamigasa",
 	name_color: "8650AC",
@@ -251,8 +259,8 @@ export const SpelledAndPaintedFukushima = {
 	market_actions: [
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D11594556976610170043",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	commodity: 0,
 	market_tradable_restriction: 7,
@@ -264,21 +272,21 @@ export const SpelledAndPaintedFukushima = {
 			internal_name: "rarity4",
 			localized_category_name: "Quality",
 			localized_tag_name: "Unusual",
-			color: "8650AC"
+			color: "8650AC",
 		},
 		{
 			category: "Type",
 			internal_name: "misc",
 			localized_category_name: "Type",
-			localized_tag_name: "Cosmetic"
+			localized_tag_name: "Cosmetic",
 		},
 		{
 			category: "Class",
 			internal_name: "Soldier",
 			localized_category_name: "Class",
-			localized_tag_name: "Soldier"
-		}
-	]
+			localized_tag_name: "Soldier",
+		},
+	],
 };
 
 export const StrangeKritzKriegWithPart = {
@@ -290,24 +298,26 @@ export const StrangeKritzKriegWithPart = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwgHWAnqvTlPjdrZAfOeD-VOmt9h58kA3WY-kAAiZ-HkM2M1IVSSVvgOBKQ49Vu_XHBmvZYwBIfjr_UWJ1saY-ME6A",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwgHWAnqvTlPjdrZAfOeD-VOmt9h58kA3WY-kAAiZ-HkM2M1IVSSVvgOBKQ49Vu_XHBmvZYwBIfjr_UWJ1saY-ME6A",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwgHWAnqvTlPjdrZAfOeD-VOmt9h58kA3WY-kAAiZ-HkM2M1IVSSVvgOBKQ49Vu_XHBmvZYwBIfjr_UWJ1saY-ME6A",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwgHWAnqvTlPjdrZAfOeD-VOmt9h58kA3WY-kAAiZ-HkM2M1IVSSVvgOBKQ49Vu_XHBmvZYwBIfjr_UWJ1saY-ME6A",
 	descriptions: [
 		{ value: "(Ubers: 0)", color: "756b5e" },
 		{ value: "(Allied Healing Done: 0)", color: "756b5e" },
 		{ value: "ÜberCharge grants 100% critical chance" },
 		{ value: "+25% ÜberCharge rate", color: "7ea9d1" },
 		{ value: "Killstreaks Active", color: "7ea9d1" },
-		{ value: "''Charge in and kill the French!''" }
+		{ value: "''Charge in and kill the French!''" },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=35&lang=en_US",
-			name: "Item Wiki Page..."
-		}
+			name: "Item Wiki Page...",
+		},
 	],
-	fraudwarnings: [ "This item has been renamed.\nOriginal name: \"Kritzkrieg\"" ],
+	fraudwarnings: ["This item has been renamed.\nOriginal name: \"Kritzkrieg\""],
 	name: "''BLITZKRIEG''",
 	name_color: "CF6A32",
 	type: "Strange Medi Gun - Kill Assists: 0",
@@ -323,21 +333,21 @@ export const StrangeKritzKriegWithPart = {
 			internal_name: "strange",
 			localized_category_name: "Quality",
 			localized_tag_name: "Strange",
-			color: "CF6A32"
+			color: "CF6A32",
 		},
 		{
 			category: "Type",
 			internal_name: "secondary",
 			localized_category_name: "Type",
-			localized_tag_name: "Secondary weapon"
+			localized_tag_name: "Secondary weapon",
 		},
 		{
 			category: "Class",
 			internal_name: "Medic",
 			localized_category_name: "Class",
-			localized_tag_name: "Medic"
-		}
-	]
+			localized_tag_name: "Medic",
+		},
+	],
 };
 
 export const TeamShinePartedCarbonando = {
@@ -349,23 +359,24 @@ export const TeamShinePartedCarbonando = {
 	amount: "1",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgENYwUuVSTvvTxKj93oMvaFCe0Pld4K55xU2j1UnQBpM-b7YGdlIwDDUvMKCKRo9gy0UHFh6p81AoKyr-wFLAnr4oPONrQsY40ZH96QBKHlPdYBtw",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgENYwUuVSTvvTxKj93oMvaFCe0Pld4K55xU2j1UnQBpM-b7YGdlIwDDUvMKCKRo9gy0UHFh6p81AoKyr-wFLAnr4oPONrQsY40ZH96QBKHlPdYBtw",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgENYwUuVSTvvTxKj93oMvaFCe0Pld4K55xU2j1UnQBpM-b7YGdlIwDDUvMKCKRo9gy0UHFh6p81AoKyr-wFLAnr4oPONrQsY40ZH96QBKHlPdYBtw",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgENYwUuVSTvvTxKj93oMvaFCe0Pld4K55xU2j1UnQBpM-b7YGdlIwDDUvMKCKRo9gy0UHFh6p81AoKyr-wFLAnr4oPONrQsY40ZH96QBKHlPdYBtw",
 	descriptions: [
 		{ value: "(Kill Assists: 0)", color: "756b5e" },
 		{ value: "Sheen: Team Shine", color: "7ea9d1" },
-		{ value: "Killstreaks Active", color: "7ea9d1" }
+		{ value: "Killstreaks Active", color: "7ea9d1" },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=903&lang=en_US",
-			name: "Item Wiki Page..."
-		}
+			name: "Item Wiki Page...",
+		},
 	],
 	fraudwarnings: [
-		"This item has been renamed.\n" +
-      "Original name: \"Carbonado Botkiller Medi Gun Mk.I\""
+		"This item has been renamed.\n" + "Original name: \"Carbonado Botkiller Medi Gun Mk.I\"",
 	],
 	name: "''The K/DA Life Support Preserver~ ♥''",
 	name_color: "CF6A32",
@@ -382,21 +393,21 @@ export const TeamShinePartedCarbonando = {
 			internal_name: "strange",
 			localized_category_name: "Quality",
 			localized_tag_name: "Strange",
-			color: "CF6A32"
+			color: "CF6A32",
 		},
 		{
 			category: "Type",
 			internal_name: "secondary",
 			localized_category_name: "Type",
-			localized_tag_name: "Secondary weapon"
+			localized_tag_name: "Secondary weapon",
 		},
 		{
 			category: "Class",
 			internal_name: "Medic",
 			localized_category_name: "Class",
-			localized_tag_name: "Medic"
-		}
-	]
+			localized_tag_name: "Medic",
+		},
+	],
 };
 
 export const HauntedHalloweenBeepMan = {
@@ -405,26 +416,28 @@ export const HauntedHalloweenBeepMan = {
 	instanceid: "629236864",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhnnvSh8hcnoMv6NGucF1dszsMBXi2EywVJ4YrKwaWYwcQGVBfUPWPA_rVnpC3M2sMZlUo7v8ulIOVK4vadAw3k",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhnnvSh8hcnoMv6NGucF1dszsMBXi2EywVJ4YrKwaWYwcQGVBfUPWPA_rVnpC3M2sMZlUo7v8ulIOVK4vadAw3k",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhnnvSh8hcnoMv6NGucF1dszsMBXi2EywVJ4YrKwaWYwcQGVBfUPWPA_rVnpC3M2sMZlUo7v8ulIOVK4vadAw3k",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhnnvSh8hcnoMv6NGucF1dszsMBXi2EywVJ4YrKwaWYwcQGVBfUPWPA_rVnpC3M2sMZlUo7v8ulIOVK4vadAw3k",
 	descriptions: [
 		{ value: "(Carnival Underworld Kills: 0)", color: "756b5e" },
 		{ value: "(Carnival Games Won: 0)", color: "756b5e" },
 		{
 			value: "Holiday Restriction: Halloween / Full Moon",
-			color: "d83636"
-		}
+			color: "d83636",
+		},
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=30509&lang=en_US",
-			name: "Item Wiki Page..."
+			name: "Item Wiki Page...",
 		},
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D422539663328697647",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	name: "Strange Haunted Beep Man",
 	name_color: "38f3ab",
@@ -434,8 +447,8 @@ export const HauntedHalloweenBeepMan = {
 	market_actions: [
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D422539663328697647",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	commodity: 0,
 	market_tradable_restriction: 7,
@@ -447,21 +460,21 @@ export const HauntedHalloweenBeepMan = {
 			internal_name: "haunted",
 			localized_category_name: "Quality",
 			localized_tag_name: "Haunted",
-			color: "38f3ab"
+			color: "38f3ab",
 		},
 		{
 			category: "Type",
 			internal_name: "misc",
 			localized_category_name: "Type",
-			localized_tag_name: "Cosmetic"
+			localized_tag_name: "Cosmetic",
 		},
 		{
 			category: "Class",
 			internal_name: "Engineer",
 			localized_category_name: "Class",
-			localized_tag_name: "Engineer"
-		}
-	]
+			localized_tag_name: "Engineer",
+		},
+	],
 };
 
 export const NormalProfessionalKillstreakBat = {
@@ -470,20 +483,22 @@ export const NormalProfessionalKillstreakBat = {
 	instanceid: "11040671",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwUQSSTuuSpEjYbiXaHaCuVSyI9l4MQCjjJvk1IrYbTjMmM2cFyRAPYICqI5pFruWX8wptdtU1jiacVz",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwUQSSTuuSpEjYbiXaHaCuVSyI9l4MQCjjJvk1IrYbTjMmM2cFyRAPYICqI5pFruWX8wptdtU1jiacVz",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwUQSSTuuSpEjYbiXaHaCuVSyI9l4MQCjjJvk1IrYbTjMmM2cFyRAPYICqI5pFruWX8wptdtU1jiacVz",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwUQSSTuuSpEjYbiXaHaCuVSyI9l4MQCjjJvk1IrYbTjMmM2cFyRAPYICqI5pFruWX8wptdtU1jiacVz",
 	descriptions: [
 		{ value: "Killstreaker: Incinerator", color: "7ea9d1" },
-		{ value: "Killstreaks Active", color: "7ea9d1" }
+		{ value: "Killstreaks Active", color: "7ea9d1" },
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=0&lang=en_US",
-			name: "Item Wiki Page..."
-		}
+			name: "Item Wiki Page...",
+		},
 	],
-	fraudwarnings: [ "This item has been renamed.\nOriginal name: \"Bat\"" ],
+	fraudwarnings: ["This item has been renamed.\nOriginal name: \"Bat\""],
 	name: "''‮‮''",
 	name_color: "B2B2B2",
 	type: "Level 1 Bat",
@@ -499,21 +514,21 @@ export const NormalProfessionalKillstreakBat = {
 			internal_name: "Normal",
 			localized_category_name: "Quality",
 			localized_tag_name: "Normal",
-			color: "B2B2B2"
+			color: "B2B2B2",
 		},
 		{
 			category: "Type",
 			internal_name: "melee",
 			localized_category_name: "Type",
-			localized_tag_name: "Melee weapon"
+			localized_tag_name: "Melee weapon",
 		},
 		{
 			category: "Class",
 			internal_name: "Scout",
 			localized_category_name: "Class",
-			localized_tag_name: "Scout"
-		}
-	]
+			localized_tag_name: "Scout",
+		},
+	],
 };
 
 export const StrangeElevatedNormalFlameThrower = {
@@ -522,30 +537,33 @@ export const StrangeElevatedNormalFlameThrower = {
 	instanceid: "45747668",
 	currency: 0,
 	background_color: "3C352E",
-	icon_url: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwEdXBbnrDBRh9_jH82ACfIHnpRt4MQF3Tc7lFd_ZOCxYm5kdFKTVvEKCaRopli7Cn5isZAxV4bm9u4AZ0yx42fOX6Lt",
-	icon_url_large: "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwEdXBbnrDBRh9_jH82ACfIHnpRt4MQF3Tc7lFd_ZOCxYm5kdFKTVvEKCaRopli7Cn5isZAxV4bm9u4AZ0yx42fOX6Lt",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwEdXBbnrDBRh9_jH82ACfIHnpRt4MQF3Tc7lFd_ZOCxYm5kdFKTVvEKCaRopli7Cn5isZAxV4bm9u4AZ0yx42fOX6Lt",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwEdXBbnrDBRh9_jH82ACfIHnpRt4MQF3Tc7lFd_ZOCxYm5kdFKTVvEKCaRopli7Cn5isZAxV4bm9u4AZ0yx42fOX6Lt",
 	descriptions: [
 		{ value: "(Damage Dealt: 0)", color: "756b5e" },
 		{ value: "(Teammates Extinguished: 0)", color: "756b5e" },
 		{
 			value: "Extinguishing teammates restores 20 health",
-			color: "7ea9d1"
+			color: "7ea9d1",
 		},
 		{
-			value: "Afterburn reduces Medi Gun healing and resist shield effects.\n" +
-        "Alt-Fire: Release a blast of air that pushes enemies and projectiles and extinguishes teammates that are on fire."
-		}
+			value:
+        "Afterburn reduces Medi Gun healing and resist shield effects.\n" +
+        "Alt-Fire: Release a blast of air that pushes enemies and projectiles and extinguishes teammates that are on fire.",
+		},
 	],
 	tradable: 1,
 	actions: [
 		{
 			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=208&lang=en_US",
-			name: "Item Wiki Page..."
+			name: "Item Wiki Page...",
 		},
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D16330055015698336298",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	name: "Strange Flame Thrower",
 	name_color: "B2B2B2",
@@ -555,8 +573,8 @@ export const StrangeElevatedNormalFlameThrower = {
 	market_actions: [
 		{
 			link: "steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D16330055015698336298",
-			name: "Inspect in Game..."
-		}
+			name: "Inspect in Game...",
+		},
 	],
 	commodity: 0,
 	market_tradable_restriction: 7,
@@ -568,19 +586,153 @@ export const StrangeElevatedNormalFlameThrower = {
 			internal_name: "Normal",
 			localized_category_name: "Quality",
 			localized_tag_name: "Normal",
-			color: "B2B2B2"
+			color: "B2B2B2",
 		},
 		{
 			category: "Type",
 			internal_name: "primary",
 			localized_category_name: "Type",
-			localized_tag_name: "Primary weapon"
+			localized_tag_name: "Primary weapon",
 		},
 		{
 			category: "Class",
 			internal_name: "Pyro",
 			localized_category_name: "Class",
-			localized_tag_name: "Pyro"
-		}
-	]
+			localized_tag_name: "Pyro",
+		},
+	],
+};
+
+export const DoubleSpelledStrangeFlamethrower = {
+	appid: 440,
+	classid: "4455141782",
+	instanceid: "4778856628",
+	currency: 0,
+	background_color: "3C352E",
+	icon_url:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwMDWiTysDRMj8H1GfuCCfQPieU55IJS3Hhul1QpY7DgMjU1JACWWaIOWac-9ly9CnEzuMIzDYG0ruxRKwXos4rALfByZ2I6H6Yn",
+	icon_url_large:
+    "fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEIUwMDWiTysDRMj8H1GfuCCfQPieU55IJS3Hhul1QpY7DgMjU1JACWWaIOWac-9ly9CnEzuMIzDYG0ruxRKwXos4rALfByZ2I6H6Yn",
+	descriptions: [
+		{
+			value: "(Kills During Halloween: 39)",
+			color: "756b5e",
+		},
+		{
+			value: "(Kills Under A Full Moon: 26)",
+			color: "756b5e",
+		},
+		{
+			value: "(Kills during Victory Time: 10)",
+			color: "756b5e",
+		},
+		{
+			value: "Crafted by Little Sticks",
+			color: "7ea9d1",
+		},
+		{
+			value:
+        "Build 'Mmmph' by dealing damage.\nAlt-Fire on full 'Mmmph': Taunt to gain crit for several seconds.\nInvulnerable while 'Mmmph' taunting.",
+			color: "7ea9d1",
+		},
+		{
+			value: "Halloween: Halloween Fire (spell only active during event)",
+			color: "7ea9d1",
+		},
+		{
+			value: "Halloween: Exorcism (spell only active during event)",
+			color: "7ea9d1",
+		},
+		{
+			value: "Killstreaker: Fire Horns",
+			color: "7ea9d1",
+		},
+		{
+			value: "Sheen: Deadly Daffodil",
+			color: "7ea9d1",
+		},
+		{
+			value: "Killstreaks Active",
+			color: "7ea9d1",
+		},
+		{
+			value: "No random critical hits",
+			color: "d83636",
+		},
+		{
+			value: "No airblast",
+			color: "d83636",
+		},
+		{
+			value:
+        "Being a revolutionary appliance capable of awakening the fire element phlogiston that exists in all combustible creatures, which is to say, all of them.",
+		},
+		{
+			value: " ",
+		},
+		{
+			value: "Dr. Grordbort's Moonman Pack",
+			color: "e1e10f",
+		},
+		{
+			value: " ",
+		},
+		{
+			value: "The Phlogistinator",
+			color: "8b8989",
+		},
+		{
+			value: "The Third Degree",
+			color: "8b8989",
+		},
+		{
+			value: "The Manmelter",
+			color: "8b8989",
+		},
+		{
+			value: "The Moonman Backpack",
+			color: "8b8989",
+		},
+		{
+			value: "The Bubble Pipe",
+			color: "8b8989",
+		},
+	],
+	tradable: 1,
+	actions: [
+		{
+			link: "http://wiki.teamfortress.com/scripts/itemredirect.php?id=594&lang=en_US",
+			name: "Item Wiki Page...",
+		},
+	],
+	name: "Strange Professional Killstreak Phlogistinator",
+	name_color: "CF6A32",
+	type: "Strange Flame Thrower - Kills: 285",
+	market_name: "Strange Professional Killstreak Phlogistinator",
+	market_hash_name: "Strange Professional Killstreak Phlogistinator",
+	commodity: 0,
+	market_tradable_restriction: 7,
+	market_marketable_restriction: 0,
+	marketable: 1,
+	tags: [
+		{
+			category: "Quality",
+			internal_name: "strange",
+			localized_category_name: "Quality",
+			localized_tag_name: "Strange",
+			color: "CF6A32",
+		},
+		{
+			category: "Type",
+			internal_name: "primary",
+			localized_category_name: "Type",
+			localized_tag_name: "Primary weapon",
+		},
+		{
+			category: "Class",
+			internal_name: "Pyro",
+			localized_category_name: "Class",
+			localized_tag_name: "Pyro",
+		},
+	],
 };

--- a/__tests__/toFullSKU.spec.ts
+++ b/__tests__/toFullSKU.spec.ts
@@ -1,5 +1,5 @@
 import { toFullSKU } from "../lib/toFullSKU";
-import { SpelledAndPaintedFukushima, TeamShinePartedCarbonando, AustraliumGoldUnusualAviator, StrangeKritzKriegWithPart, HauntedHalloweenBeepMan, NormalProfessionalKillstreakBat, StrangeElevatedNormalFlameThrower } from "./constants/EconItems";
+import { SpelledAndPaintedFukushima, TeamShinePartedCarbonando, AustraliumGoldUnusualAviator, StrangeKritzKriegWithPart, HauntedHalloweenBeepMan, NormalProfessionalKillstreakBat, StrangeElevatedNormalFlameThrower, DoubleSpelledStrangeFlamethrower } from "./constants/EconItems";
 
 
 test("paint passed along correctly", () => {
@@ -45,4 +45,9 @@ test("Normal quality", () => {
 test("Elevated quality doesn't hinder base quality", () => {
 	const sku = toFullSKU({ ...StrangeElevatedNormalFlameThrower, assetid: "" });
 	expect(sku).toBe("208;0;strange;prt6020;prt6056");
+});
+
+test("differently named spells are handled",()=>{
+	const sku = toFullSKU({ ...DoubleSpelledStrangeFlamethrower, assetid: "" });
+	expect(sku).toBe("594;11;kt-3;spl8921;spl8923;shn1;ksr1");
 });

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
-import { EconItem } from "tf2-item-format"
-import { toBaseSKU } from "./lib/toBaseSKU"
-import { toFullSKU } from "./lib/toFullSKU"
-import { parseSKU } from "./lib/parseSKU"
-import { toBaseName } from "./lib/toName"
-import { stripFullSKU } from "./lib/stripFullSKU"
+import { EconItem } from "tf2-item-format";
+import { toBaseSKU } from "./lib/toBaseSKU";
+import { toFullSKU } from "./lib/toFullSKU";
+import { parseSKU } from "./lib/parseSKU";
+import { toBaseName } from "./lib/toName";
+import { stripFullSKU } from "./lib/stripFullSKU";
 
-export { EconItem, toBaseSKU, toFullSKU, parseSKU, toBaseName, stripFullSKU }
+export { EconItem, toBaseSKU, toFullSKU, parseSKU, toBaseName, stripFullSKU };

--- a/lib/enums/Spell.ts
+++ b/lib/enums/Spell.ts
@@ -1,21 +1,65 @@
-import { schema } from "tf2-item-format";
-
-// Defindex constants
-const HALLOWEEN_SPELL_FIRST_VOICE = 8905;
-const HALLOWEEN_SPELL_LAST_VOICE = HALLOWEEN_SPELL_FIRST_VOICE + (9 - 1); // 9 classes, - 1
-const HALLOWEEN_FIRST_SPELL = HALLOWEEN_SPELL_FIRST_VOICE;
-const HALLOWEEN_LAST_SPELL = 8925;
-const HALLOWEEN_PREFIX = "Halloween Spell:";
-const HALLOWEEN_VFB_NAME = "Voices From Below";
-
-
-export function getSpellName(defindex: number) {
-	if (defindex < HALLOWEEN_FIRST_SPELL || defindex > HALLOWEEN_LAST_SPELL) throw "Not a spell";
-	if (defindex >= HALLOWEEN_SPELL_FIRST_VOICE && defindex <= HALLOWEEN_SPELL_LAST_VOICE) return `${HALLOWEEN_PREFIX} ${HALLOWEEN_VFB_NAME}`;
-	return schema.getName(defindex);
+export enum Spell {
+  PutrescentPigmentation = 8900,
+  DieJob = 8901,
+  ChromaticCorruption = 8902,
+  SpectralSpectrum = 8903,
+  SinisterStaining = 8904,
+  VoicesFromBelow = 8905,
+  TeamSpiritFootprints = 8914,
+  GangreenFootprints = 8915,
+  CorpseGrayFootprints = 8916,
+  ViolentVioletFootprints = 8917,
+  RottenOrangeFootprints = 8918,
+  BruisedPurpleFootprints = 8919,
+  HeadlessHorseshoes = 8920,
+  Exorcism = 8921,
+  PumpkinBombs = 8922,
+  HalloweenFire = 8923,
 }
 
-export function getSpellDefindex(name: string) {
-	if (name == `${HALLOWEEN_PREFIX} ${HALLOWEEN_VFB_NAME}`) return HALLOWEEN_SPELL_FIRST_VOICE;
-	return schema.getDefindex(name);
+const SpellEnums = {
+	"Putrescent Pigmentation": Spell.PutrescentPigmentation,
+	"Die Job": Spell.DieJob,
+	"Chromatic Corruption": Spell.ChromaticCorruption,
+	"Spectral Spectrum": Spell.SpectralSpectrum,
+	"Sinister Staining": Spell.SinisterStaining,
+	"Voices From Below": Spell.VoicesFromBelow,
+	"Team Spirit Footprints": Spell.TeamSpiritFootprints,
+	"Gangreen Footprints": Spell.GangreenFootprints,
+	"Corpse Gray Footprints": Spell.CorpseGrayFootprints,
+	"Violent Violet Footprints": Spell.ViolentVioletFootprints,
+	"Rotten Orange Footprints": Spell.RottenOrangeFootprints,
+	"Bruised Purple Footprints": Spell.BruisedPurpleFootprints,
+	"Headless Horseshoes": Spell.HeadlessHorseshoes,
+	Exorcism: Spell.Exorcism,
+	"Pumpkin Bombs": Spell.PumpkinBombs,
+	"Halloween Fire": Spell.HalloweenFire,
+
+	[Spell.PutrescentPigmentation]: "Putrescent Pigmentation",
+	[Spell.DieJob]: "Die Job",
+	[Spell.ChromaticCorruption]: "Chromatic Corruption",
+	[Spell.SpectralSpectrum]: "Spectral Spectrum",
+	[Spell.SinisterStaining]: "Sinister Staining",
+	[Spell.VoicesFromBelow]: "Voices From Below",
+	[Spell.TeamSpiritFootprints]: "Team Spirit Footprints",
+	[Spell.GangreenFootprints]: "Gangreen Footprints",
+	[Spell.CorpseGrayFootprints]: "Corpse Gray Footprints",
+	[Spell.ViolentVioletFootprints]: "Violent Violet Footprints",
+	[Spell.RottenOrangeFootprints]: "Rotten Orange Footprints",
+	[Spell.BruisedPurpleFootprints]: "Bruised Purple Footprints",
+	[Spell.HeadlessHorseshoes]: "Headless Horseshoes",
+	[Spell.Exorcism]: "Exorcism",
+	[Spell.PumpkinBombs]: "Pumpkin Bombs",
+	[Spell.HalloweenFire]: "Halloween Fire",
+};
+
+export function getSpellEnum(spell: string): Spell {
+	const spellName = spell.replace("Halloween Spell: ", "");
+	if (spellName in SpellEnums) return SpellEnums[spellName];
+	throw "Spell not found";
+}
+
+export function getSpellName(spellEnum: Spell): string {
+	if (spellEnum in SpellEnums) return "Halloween Spell: " + SpellEnums[spellEnum];
+	throw "SpellEnum not found";
 }

--- a/lib/toFullSKU.ts
+++ b/lib/toFullSKU.ts
@@ -3,20 +3,24 @@ import { toBaseSKU } from "./toBaseSKU";
 import { getSheenEnum } from "./enums/Sheen";
 import { getKillstreakerEnum } from "./enums/Killstreaker";
 import { SKUPrefix } from "./enums/SKUPrefix";
-import { getSpellDefindex } from "./enums/Spell";
+import { getSpellEnum } from "./enums/Spell";
 import { getPartDefindex } from "./enums/Part";
 
 /**
  * Return full SKU of EconItem
  */
 export function toFullSKU(econItem: EconItem): string {
-	const { paint, parts, spells, sheen, killstreaker, tradable } = parseEconItem(econItem, true, true);
+	const { paint, parts, spells, sheen, killstreaker, tradable } = parseEconItem(
+		econItem,
+		true,
+		true
+	);
 	let sku = toBaseSKU(econItem);
 
 	function attachToSKU(component) {
 		sku = `${sku};${component}`;
 	}
-    
+
 	if (paint != null) attachToSKU(`${SKUPrefix.Paint}${schema.getDefindex(paint)}`);
 
 	if (parts != null) {
@@ -31,13 +35,14 @@ export function toFullSKU(econItem: EconItem): string {
 
 	if (spells != null) {
 		const spellsDefindices = [];
-		for (const spell of spells) spellsDefindices.push(getSpellDefindex(`Halloween Spell: ${spell}`));
+		for (const spell of spells) spellsDefindices.push(getSpellEnum(`Halloween Spell: ${spell}`));
 		spellsDefindices.sort();
 		for (const spellDefindex of spellsDefindices) attachToSKU(`${SKUPrefix.Spell}${spellDefindex}`);
 	}
 
 	if (sheen != null) attachToSKU(`${SKUPrefix.Sheen}${getSheenEnum(sheen)}`);
-	if (killstreaker != null) attachToSKU(`${SKUPrefix.Killstreaker}${getKillstreakerEnum(killstreaker)}`);
+	if (killstreaker != null)
+		attachToSKU(`${SKUPrefix.Killstreaker}${getKillstreakerEnum(killstreaker)}`);
 
 	if (!tradable) attachToSKU("untradable");
 


### PR DESCRIPTION
The "Pumpkin Bombs" and "Halloween Fire" Spells were resulting in `splnull`, due to having different (or multiple) names within the Tf2 Schema. This has been rectified by creating an Enum for Spells, rather than relying on the Schema. The new Enum provides backward compatibility by using the existing defindexes when possible. 